### PR TITLE
revert(deps): update dependency com.diffplug.spotless:spotless-plugin-gradle to v6.25.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ mockk-android = { module = "io.mockk:mockk-android", version.ref = "io-mockk" }
 
 gradle-versions = "com.github.ben-manes:gradle-versions-plugin:0.51.0"
 
-spotless-gradle = "com.diffplug.spotless:spotless-plugin-gradle:6.25.0"
+spotless-gradle = "com.diffplug.spotless:spotless-plugin-gradle:6.23.3"
 
 squareup-kotlinpoet = "com.squareup:kotlinpoet:1.16.0"
 


### PR DESCRIPTION
Reverts AniTrend/support-query-builder#147 as it currently doesn't work with even with [ktlint-v1.1.1](https://github.com/AniTrend/support-query-builder/pull/152)